### PR TITLE
Fixed typo that prevented compiling matrix example on Linux

### DIFF
--- a/arduino/SparkleShield/examples/Matrix/Matrix.ino
+++ b/arduino/SparkleShield/examples/Matrix/Matrix.ino
@@ -1,6 +1,6 @@
 #include <FastLED.h>
 #include <SparkleShield.h>
-#include <Math.h>
+#include <math.h>
 
 #define BRIGHTNESS 64 
 


### PR DESCRIPTION
# include <Math.h> does not work with case-sensitive filesystems/OSes.
